### PR TITLE
fix: ensure DKMS builds i915-sriov for all installed kernels

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -22,6 +22,7 @@ apt install -y --install-recommends \
   build-essential \
   dkms \
   linux-headers-amd64 \
+  "linux-headers-$(uname -r)" \
   cloud-init \
   nfs-common \
   firmware-misc-nonfree \
@@ -34,6 +35,11 @@ apt install -y --install-recommends \
 echo 'Installing Intel SR-IOV DKMS Driver...'
 curl -L -s -S -o i915.deb "https://github.com/strongtz/i915-sriov-dkms/releases/download/2026.05.03/i915-sriov-dkms_2026.05.03_amd64.deb"
 dpkg -i i915.deb && rm i915.deb
+
+# DKMS postinst only builds for the running kernel, which may differ from
+# the kernel installed by full-upgrade. Build explicitly for all kernels.
+echo 'Building i915-sriov-dkms for all installed kernels...'
+dkms autoinstall
 
 # ----------------------------
 # Switch network stack
@@ -77,7 +83,7 @@ if ! grep -q '^GRUB_TIMEOUT_STYLE=hidden' /etc/default/grub; then
 fi
 
 update-grub
-update-initramfs -u
+update-initramfs -u -k all
 
 # ----------------------------
 # Reset machine ID


### PR DESCRIPTION
## Problem

After the recent `i915-sriov-dkms` version bump, GPU passthrough is broken on all worker nodes. The VMs boot with the **stock kernel i915 module** instead of the DKMS SR-IOV version, causing:

```
i915 0000:01:00.0: [drm] *ERROR* Device is non-operational; MMIO access returns 0xFFFFFFFF!
i915 0000:01:00.0: [drm] *ERROR* Device initialization failed (-5)
```

No `/dev/dri/renderD128` → no `gpu.intel.com/i915` resources → `FailedScheduling` for Jellyfin, Immich, ConvertX.

## Root Cause

During Packer build, a **kernel version mismatch** causes DKMS to silently skip the build:

1. Packer VM boots with kernel `6.12.73+deb13-amd64` (base image)
2. `apt full-upgrade` installs kernel `6.12.85+deb13-amd64` (not yet running)
3. `linux-headers-amd64` installs headers for `6.12.85` only
4. `dpkg -i i915.deb` → DKMS postinst tries to build for the **running** kernel (`6.12.73`) → no headers → silently skips
5. Produced VM boots into `6.12.85` → no DKMS module available → stock i915 loads → can't operate VFs

## Fix

1. Also install `linux-headers-$(uname -r)` so DKMS can build for the running kernel during Packer
2. Run `dkms autoinstall` explicitly after package install to ensure all kernels are covered
3. Use `update-initramfs -u -k all` to include the module in all kernel initramfs images