### PR TITLE
chore(deps): pin i915-sriov-dkms to 2026.03.05.2

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -32,7 +32,7 @@ apt install -y --install-recommends \
 # Install Intel SR-IOV driver
 # ----------------------------
 echo 'Installing Intel SR-IOV DKMS Driver...'
-curl -L -s -S -o i915.deb "https://github.com/strongtz/i915-sriov-dkms/releases/download/2026.03.05.1/i915-sriov-dkms_2026.03.05.1_amd64.deb"
+curl -L -s -S -o i915.deb "https://github.com/strongtz/i915-sriov-dkms/releases/download/2026.03.05.2/i915-sriov-dkms_2026.03.05.2_amd64.deb"
 dpkg -i i915.deb && rm i915.deb
 
 # ----------------------------


### PR DESCRIPTION
## Why

`2026.03.05.2` is the last i915-sriov-dkms release supporting kernels **v6.12–v6.19**. The golden image is built from `debian-13.5.0-amd64-netinst.iso`, which ships kernel **6.12** (point releases don't bump the kernel major/minor). Newer releases (`2026.05.03+`) require kernel **6.17.x–7.0.x** and therefore fail to build in `scripts/bootstrap.sh`.

This bumps from `2026.03.05.1` → `2026.03.05.2` (same supported-kernel line, plus the "Fix conftest on gcc 13" change).

## Relationship to #94

Renovate PR #94 (bump to `2026.05.06`) is intentionally **left open** as a standing reminder. Once a future Debian release ships a ≥6.17 kernel, that PR can be merged to move forward.

> Keep host and VM driver versions in sync — see the matching Ansible PR.