### PR TITLE
docs: add SECURITY policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+This repository is part of a **personal homelab**, maintained for learning and home use. It is
+provided **as-is**, with **no service-level agreement** and no guarantee of timely fixes.
+
+## Reporting a vulnerability
+
+If you find a security issue, please report it **privately** — do not open a public issue that
+discloses details. Use GitHub's private vulnerability reporting if available, or contact the
+repository owner directly, and allow time for the issue to be addressed before any public
+disclosure.
+
+## Supported versions
+
+Only the current state of the default branch (`main`) is maintained. Older commits, tags, and
+branches receive no security support.


### PR DESCRIPTION
Adds a personal-homelab security policy (report privately, no SLA, only `main` maintained). Docs-only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>